### PR TITLE
Fix unused function warning on little-endian

### DIFF
--- a/Crc32.cpp
+++ b/Crc32.cpp
@@ -48,6 +48,7 @@
 const uint32_t Polynomial = 0xEDB88320;
 
 /// swap endianess
+#if __BYTE_ORDER == __BIG_ENDIAN
 static inline uint32_t swap(uint32_t x)
 {
 #if defined(__GNUC__) || defined(__clang__)
@@ -59,6 +60,7 @@ static inline uint32_t swap(uint32_t x)
          (x << 24);
 #endif
 }
+#endif
 
 
 /// Slicing-By-16


### PR DESCRIPTION
The swap function is only ever called when __BYTE_ORDER == __BIG_ENDIAN,
so on little-endian systems, Clang would emit a warning about swap being
unused.