### PR TITLE
The __BYTE_ORDER and __BIG_ENDIAN macros are not defined at MAC OS

### DIFF
--- a/Crc32.cpp
+++ b/Crc32.cpp
@@ -35,6 +35,11 @@
   // defines __BYTE_ORDER as __LITTLE_ENDIAN or __BIG_ENDIAN
   #include <sys/param.h>
 
+  #if !defined(__BYTE_ORDER) && defined(BYTE_ORDER) && !defined(__BIG_ENDIAN) && defined(BIG_ENDIAN)
+    #define __BYTE_ORDER BYTE_ORDER
+    #define __BIG_ENDIAN BIG_ENDIAN
+  #endif
+
   #ifdef __GNUC__
     #define PREFETCH(location) __builtin_prefetch(location)
   #else
@@ -43,6 +48,9 @@
   #endif
 #endif
 
+#if !defined(__BYTE_ORDER) || !defined(__BIG_ENDIAN)
+#error byte order is not defined
+#endif
 
 /// zlib's CRC32 polynomial
 const uint32_t Polynomial = 0xEDB88320;


### PR DESCRIPTION
X CODE Version 11.2.1 (11B500)
all hash functions except of 1byte-version uses big_endian by default - it is a reason of wrong hashes