### PR TITLE
Use __BYTE_ORDER__ if available and __BYTE_ORDER is not set

### DIFF
--- a/Crc32.cpp
+++ b/Crc32.cpp
@@ -55,6 +55,10 @@
   #endif
 #endif
 
+#if !defined(__BYTE_ORDER) && defined(__BYTE_ORDER__)
+  #define __BYTE_ORDER __BYTE_ORDER__
+#endif
+
 // abort if byte order is undefined
 #if !defined(__BYTE_ORDER)
 #error undefined byte order, compile with -D__BYTE_ORDER=1234 (if little endian) or -D__BYTE_ORDER=4321 (big endian)


### PR DESCRIPTION
Compiling on MacOS failed because __BYTE_ORDER is not defined.  However,
__BYTE_ORDER__ is defined so use that when available.