### PR TITLE
implement slicing-by-2

### DIFF
--- a/Crc32.h
+++ b/Crc32.h
@@ -9,6 +9,7 @@
 // if running on an embedded system, you might consider shrinking the
 // big Crc32Lookup table by undefining these lines:
 #define CRC32_USE_LOOKUP_TABLE_BYTE
+#define CRC32_USE_LOOKUP_TABLE_SLICING_BY_2
 #define CRC32_USE_LOOKUP_TABLE_SLICING_BY_4
 #define CRC32_USE_LOOKUP_TABLE_SLICING_BY_8
 #define CRC32_USE_LOOKUP_TABLE_SLICING_BY_16
@@ -48,6 +49,11 @@ uint32_t crc32_1byte   (const void* data, size_t length, uint32_t previousCrc32 
 uint32_t crc32_1byte_tableless (const void* data, size_t length, uint32_t previousCrc32 = 0);
 /// compute CRC32 (byte algorithm) without lookup tables
 uint32_t crc32_1byte_tableless2(const void* data, size_t length, uint32_t previousCrc32 = 0);
+
+#ifdef CRC32_USE_LOOKUP_TABLE_SLICING_BY_2
+/// compute CRC32 (Slicing-by-2 algorithm)
+uint32_t crc32_2bytes  (const void* data, size_t length, uint32_t previousCrc32 = 0);
+#endif
 
 #ifdef CRC32_USE_LOOKUP_TABLE_SLICING_BY_4
 /// compute CRC32 (Slicing-by-4 algorithm)

--- a/Crc32Test.cpp
+++ b/Crc32Test.cpp
@@ -107,6 +107,15 @@ int main(int, char**)
          crc, duration, (NumBytes / (1024*1024)) / duration);
 #endif // CRC32_USE_LOOKUP_TABLE_BYTE
 
+#ifdef CRC32_USE_LOOKUP_TABLE_SLICING_BY_2
+  // two bytes at once
+  startTime = seconds();
+  crc = crc32_2bytes(data, NumBytes);
+  duration  = seconds() - startTime;
+  printf("  2 bytes at once: CRC=%08X, %.3fs, %.3f MB/s\n",
+         crc, duration, (NumBytes / (1024*1024)) / duration);
+#endif // CRC32_USE_LOOKUP_TABLE_SLICING_BY_2
+
 #ifdef CRC32_USE_LOOKUP_TABLE_SLICING_BY_4
   // four bytes at once
   startTime = seconds();

--- a/Crc32TestMultithreaded.cpp
+++ b/Crc32TestMultithreaded.cpp
@@ -147,6 +147,13 @@ int main(int argc, char* argv[])
   printf("  1 byte  at once / %d threads: CRC=%08X, %.3fs, %.3f MB/s\n",
          numThreads, crc, duration, (NumBytes / (1024*1024)) / duration);
 
+  // two bytes at once
+  startTime = seconds();
+  crc = run(crc32_2bytes, data, NumBytes, numThreads);
+  duration  = seconds() - startTime;
+  printf("  2 bytes at once / %d threads: CRC=%08X, %.3fs, %.3f MB/s\n",
+         numThreads, crc, duration, (NumBytes / (1024*1024)) / duration);
+
   // four bytes at once
   startTime = seconds();
   crc = run(crc32_4bytes, data, NumBytes, numThreads);

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@ This file tracks the main changes to my CRC32 library.
 project website: https://create.stephan-brumme.com/crc32/
 GitHub mirror:   https://github.com/stbrumme/crc32/
 
+## October   6, 2023 (version 10)
+- added Slicing-by-2
+
 ## December  6, 2019 (version 9)
 - added support for multi-threaded computation
 

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,7 @@ Algorithms:
 - half-byte
 - tableless full-byte
 - Sarwate's original algorithm
+- slicing-by-2
 - slicing-by-4
 - slicing-by-8
 - slicing-by-16


### PR DESCRIPTION
I came across a reference to a ["slicing-by-2" technique](https://www.kernel.org/doc/html/latest/staging/crc32.html), but I haven't seen this actually implemented anywhere.

This PR implements that algorithm and the speed slots right in between the single byte and slicing-by-4 variants.

On my system:
~~~~
$ ./Crc32Test 
Please wait ...
bitwise          : CRC=221F390F, 8.717s, 117.475 MB/s
half-byte        : CRC=221F390F, 5.740s, 178.384 MB/s
tableless (byte) : CRC=221F390F, 6.606s, 155.019 MB/s
tableless (byte2): CRC=221F390F, 9.292s, 110.207 MB/s
  1 byte  at once: CRC=221F390F, 2.707s, 378.304 MB/s
  2 bytes at once: CRC=221F390F, 1.687s, 606.836 MB/s
  4 bytes at once: CRC=221F390F, 0.969s, 1056.677 MB/s
  8 bytes at once: CRC=221F390F, 0.535s, 1914.827 MB/s
4x8 bytes at once: CRC=221F390F, 0.536s, 1909.030 MB/s
 16 bytes at once: CRC=221F390F, 0.281s, 3650.535 MB/s
 16 bytes at once: CRC=221F390F, 0.280s, 3651.705 MB/s (including prefetching)
    chunked      : CRC=221F390F, 0.281s, 3644.816 MB/s
~~~~

I don't have a way to test the Arduino code, but it "looks right to me".